### PR TITLE
feat: add models

### DIFF
--- a/app/models/dean_office.ts
+++ b/app/models/dean_office.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
 import Worker from '#models/worker'
-import { HasMany } from '@adonisjs/lucid/types/relations'
+import type { HasMany } from '@adonisjs/lucid/types/relations'
 import WorkingHour from '#models/working_hour'
 
 export default class DeanOffice extends BaseModel {

--- a/app/models/dean_office.ts
+++ b/app/models/dean_office.ts
@@ -1,0 +1,34 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
+import Worker from '#models/worker'
+import { HasMany } from '@adonisjs/lucid/types/relations'
+import WorkingHour from '#models/working_hour'
+
+export default class DeanOffice extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare name: string
+
+  @column()
+  declare email: string
+
+  @column()
+  declare location: string
+
+  @column()
+  declare link: string
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  @hasMany(() => Worker)
+  declare workers: HasMany<typeof Worker>
+
+  @hasMany(() => WorkingHour)
+  declare workingHours: HasMany<typeof WorkingHour>
+}

--- a/app/models/worker.ts
+++ b/app/models/worker.ts
@@ -1,0 +1,30 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import DeanOffice from '#models/dean_office'
+import { BelongsTo } from '@adonisjs/lucid/types/relations'
+
+export default class Worker extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare deansOfficeId: number
+
+  @column()
+  declare name: string
+
+  @column()
+  declare phoneNumber: string
+
+  @column()
+  declare email: string
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  @belongsTo(() => DeanOffice)
+  declare deansOffice: BelongsTo<typeof DeanOffice>
+}

--- a/app/models/worker.ts
+++ b/app/models/worker.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import DeanOffice from '#models/dean_office'
-import { BelongsTo } from '@adonisjs/lucid/types/relations'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 
 export default class Worker extends BaseModel {
   @column({ isPrimary: true })

--- a/app/models/working_hour.ts
+++ b/app/models/working_hour.ts
@@ -1,0 +1,27 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import DeanOffice from '#models/dean_office'
+import { BelongsTo } from '@adonisjs/lucid/types/relations'
+
+export default class WorkingHour extends BaseModel {
+  @column({ isPrimary: true })
+  declare deansOfficeId: number
+
+  @column()
+  declare dayOfWeek: string
+
+  @column()
+  declare openHour: string
+
+  @column()
+  declare closeHour: string
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  @belongsTo(() => DeanOffice)
+  declare deanOffice: BelongsTo<typeof DeanOffice>
+}

--- a/app/models/working_hour.ts
+++ b/app/models/working_hour.ts
@@ -1,7 +1,7 @@
 import { DateTime } from 'luxon'
 import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import DeanOffice from '#models/dean_office'
-import { BelongsTo } from '@adonisjs/lucid/types/relations'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 
 export default class WorkingHour extends BaseModel {
   @column({ isPrimary: true })


### PR DESCRIPTION
1. Użyłem stringa do open/close time - baza danych pracuje na typie time ale w js łatwiej chyba operować na stringu.
2. AFAIK adonis nie wspiera kluczy złożonych w modelach więc `WorkingHour` nie posiada jego obsługi.
3. Przy relacjach linter wyrzuca mi error, np.  `Argument type () => DeanOffice is not assignable to parameter type () => LucidModel`. Wydaje mi się, że może być to wina zbyt rygorystycznego domyślnego ustawienia sprawdzania typów (relacje pisałem zgodnie z dokumentacją więc raczej powinno być dobrze).